### PR TITLE
App window implementation

### DIFF
--- a/RhinoVR/RhinoVrDeviceDisplayConduit.cpp
+++ b/RhinoVR/RhinoVrDeviceDisplayConduit.cpp
@@ -6,8 +6,6 @@ RhinoVrDeviceDisplayConduit::RhinoVrDeviceDisplayConduit()
     CSupportChannels::SC_CALCCLIPPINGPLANES |
     CSupportChannels::SC_CALCBOUNDINGBOX |
     CSupportChannels::SC_POSTDRAWOBJECTS)
-  , m_frus_near_suggestion(-1.0)
-  , m_frus_far_suggestion(-1.0)
   , m_draw_device_mesh(false)
   , m_device_mesh(nullptr)
   , m_device_material(nullptr)
@@ -25,15 +23,7 @@ bool RhinoVrDeviceDisplayConduit::ExecConduit(
 {
   if (m_draw_device_mesh)
   {
-    if (nActiveChannel == CSupportChannels::SC_CALCCLIPPINGPLANES)
-    {
-      if (m_frus_near_suggestion >= 0.0 && m_frus_near_suggestion >= 0.0)
-      {
-        m_pChannelAttrs->m_dNear = m_frus_near_suggestion;
-        m_pChannelAttrs->m_dFar = m_frus_far_suggestion;
-      }
-    }
-    else if (nActiveChannel == CSupportChannels::SC_CALCBOUNDINGBOX)
+    if (nActiveChannel == CSupportChannels::SC_CALCBOUNDINGBOX)
     {
       ON_BoundingBox xformed_bb = m_bounding_box;
       xformed_bb.Transform(m_device_mesh_xform);
@@ -42,25 +32,22 @@ bool RhinoVrDeviceDisplayConduit::ExecConduit(
     }
     else if (nActiveChannel == CSupportChannels::SC_POSTDRAWOBJECTS)
     {
-      if (m_pDisplayAttrs->m_bShadeSurface)
+      dp.PushModelTransform(m_device_mesh_xform);
+
+      for (int i = 0; i < m_start_pts.Count(); ++i)
       {
-        dp.PushModelTransform(m_device_mesh_xform);
-
-        for (int i = 0; i < m_start_pts.Count(); ++i)
-        {
-          dp.DrawLine(m_start_pts[i], m_end_pts[i], m_colors[i]);
-        }
-
-        dp.DrawShadedMeshes(&m_device_mesh, 1, m_device_material, &m_device_cache_handle);
-
-        for (int i = 0; i < m_plane_meshes.Count(); ++i)
-        {
-          const ON_Mesh* mesh = &m_plane_meshes[i];
-          dp.DrawShadedMeshes(&mesh, 1, m_plane_materials[i], &m_mesh_plane_cache_handles[i]);
-        }
-
-        dp.PopModelTransform();
+        dp.DrawLine(m_start_pts[i], m_end_pts[i], m_colors[i]);
       }
+
+      dp.DrawShadedMeshes(&m_device_mesh, 1, m_device_material, &m_device_cache_handle);
+
+      for (int i = 0; i < m_plane_meshes.Count(); ++i)
+      {
+        const ON_Mesh* mesh = &m_plane_meshes[i];
+        dp.DrawShadedMeshes(&mesh, 1, m_plane_materials[i], &m_mesh_plane_cache_handles[i]);
+      }
+
+      dp.PopModelTransform();
     }
   }
 
@@ -96,19 +83,6 @@ void RhinoVrDeviceDisplayConduit::SetDeviceMeshXform(const ON_Xform& device_xfor
 void RhinoVrDeviceDisplayConduit::SetDeviceMeshCacheHandle(CRhinoCacheHandle* cache_handle)
 {
   m_device_cache_handle = cache_handle;
-}
-
-void RhinoVrDeviceDisplayConduit::SetFrustumNearFarSuggestion(double frus_near, double frus_far)
-{
-  if (frus_near > 0.0 && frus_far > frus_near)
-  {
-    m_frus_near_suggestion = frus_near;
-    m_frus_far_suggestion = frus_far;
-  }
-  else
-  {
-    m_frus_near_suggestion = m_frus_far_suggestion = -1.0;
-  }
 }
 
 void RhinoVrDeviceDisplayConduit::AddWindowMesh(const ON_Mesh& mesh, const CDisplayPipelineMaterial* material)
@@ -158,3 +132,97 @@ void RhinoVrDeviceDisplayConduit::InvalidateWindowMeshCache()
     m_mesh_plane_cache_handles[i] = nullptr;
   }
 }
+
+RhinoVrFrustumConduit::RhinoVrFrustumConduit()
+  : CRhinoDisplayConduit(CSupportChannels::SC_CALCCLIPPINGPLANES)
+  , m_left_frus_near(0.0)
+  , m_left_frus_far(0.0)
+  , m_left_frus_left(0.0)
+  , m_left_frus_right(0.0)
+  , m_left_frus_top(0.0)
+  , m_left_frus_bottom(0.0)
+  , m_right_frus_near(0.0)
+  , m_right_frus_far(0.0)
+  , m_right_frus_left(0.0)
+  , m_right_frus_right(0.0)
+  , m_right_frus_top(0.0)
+  , m_right_frus_bottom(0.0)
+{
+}
+
+bool RhinoVrFrustumConduit::ExecConduit(
+  CRhinoDisplayPipeline&  dp,
+  UINT                    nActiveChannel,
+  bool&                   bTerminateChannel)
+{
+  if (nActiveChannel == CSupportChannels::SC_CALCCLIPPINGPLANES)
+  {
+    if (
+      dp.m_pDisplayAttrs->GetStereoRenderContext() == CDisplayPipelineAttributes::StereoRenderContext::RenderingLeftEye &&
+      m_left_frus_near != 0.0 &&
+      m_left_frus_far != 0.0 &&
+      m_left_frus_left != 0.0 &&
+      m_left_frus_right != 0.0 &&
+      m_left_frus_top != 0.0 &&
+      m_left_frus_bottom != 0.0)
+    {
+      m_pChannelAttrs->m_dNear = m_left_frus_near;
+      m_pChannelAttrs->m_dFar = m_left_frus_far;
+      m_pChannelAttrs->m_dLeft = m_left_frus_left;
+      m_pChannelAttrs->m_dRight = m_left_frus_right;
+      m_pChannelAttrs->m_dTop = m_left_frus_top;
+      m_pChannelAttrs->m_dBottom = m_left_frus_bottom;
+    }
+
+    if (
+      dp.m_pDisplayAttrs->GetStereoRenderContext() == CDisplayPipelineAttributes::StereoRenderContext::RenderingRightEye &&
+      m_right_frus_near != 0.0 &&
+      m_right_frus_far != 0.0 &&
+      m_right_frus_left != 0.0 &&
+      m_right_frus_right != 0.0 &&
+      m_right_frus_top != 0.0 &&
+      m_right_frus_bottom != 0.0)
+    {
+      m_pChannelAttrs->m_dNear = m_right_frus_near;
+      m_pChannelAttrs->m_dFar = m_right_frus_far;
+      m_pChannelAttrs->m_dLeft = m_right_frus_left;
+      m_pChannelAttrs->m_dRight = m_right_frus_right;
+      m_pChannelAttrs->m_dTop = m_right_frus_top;
+      m_pChannelAttrs->m_dBottom = m_right_frus_bottom;
+    }
+  }
+
+  return true;
+}
+
+void RhinoVrFrustumConduit::Enable(unsigned int uiDocSerialNumber)
+{
+  CRhinoDisplayConduit::Enable(uiDocSerialNumber);
+}
+
+void RhinoVrFrustumConduit::SetFrustumLeft(
+  double frus_near, double frus_far,
+  double frus_left, double frus_right,
+  double frus_top, double frus_bottom)
+{
+  m_left_frus_near = frus_near;
+  m_left_frus_far = frus_far;
+  m_left_frus_left = frus_left;
+  m_left_frus_right = frus_right;
+  m_left_frus_top = frus_top;
+  m_left_frus_bottom = frus_bottom;
+}
+
+void RhinoVrFrustumConduit::SetFrustumRight(
+  double frus_near, double frus_far,
+  double frus_left, double frus_right,
+  double frus_top, double frus_bottom)
+{
+  m_right_frus_near = frus_near;
+  m_right_frus_far = frus_far;
+  m_right_frus_left = frus_left;
+  m_right_frus_right = frus_right;
+  m_right_frus_top = frus_top;
+  m_right_frus_bottom = frus_bottom;
+}
+

--- a/RhinoVR/RhinoVrDeviceDisplayConduit.h
+++ b/RhinoVR/RhinoVrDeviceDisplayConduit.h
@@ -14,6 +14,7 @@ public:
   void SetDeviceMeshCacheHandle(CRhinoCacheHandle* cache_handle);
 
   void SetFrustumNearFarSuggestion(double frus_near, double frus_far);
+  void AddPlane(const ON_Plane& plane, double extent_x, double extent_y, const CDisplayPipelineMaterial* material);
   void AddLine(const ON_3dPoint& from, const ON_3dPoint& to, const ON_Color& color);
   void Empty();
 
@@ -24,6 +25,11 @@ private:
   ON_SimpleArray<ON_3dPoint> m_start_pts;
   ON_SimpleArray<ON_3dPoint> m_end_pts;
   ON_SimpleArray<ON_Color> m_colors;
+
+  ON_SimpleArray<ON_Plane> m_planes;
+  ON_ClassArray<ON_Mesh> m_mesh_planes;
+  ON_SimpleArray<const CDisplayPipelineMaterial*> m_plane_materials;
+  ON_SimpleArray<CRhinoCacheHandle*> m_mesh_plane_cache_handles;
 
   bool m_draw_device_mesh;
 

--- a/RhinoVR/RhinoVrDeviceDisplayConduit.h
+++ b/RhinoVR/RhinoVrDeviceDisplayConduit.h
@@ -13,15 +13,12 @@ public:
   void SetDeviceMeshXform(const ON_Xform& device_xform);
   void SetDeviceMeshCacheHandle(CRhinoCacheHandle* cache_handle);
 
-  void SetFrustumNearFarSuggestion(double frus_near, double frus_far);
   void AddWindowMesh(const ON_Mesh& mesh, const CDisplayPipelineMaterial* material);
   void AddLine(const ON_3dPoint& from, const ON_3dPoint& to, const ON_Color& color);
   void Empty();
   void InvalidateWindowMeshCache();
 
 private:
-  double m_frus_near_suggestion;
-  double m_frus_far_suggestion;
 
   ON_SimpleArray<ON_3dPoint> m_start_pts;
   ON_SimpleArray<ON_3dPoint> m_end_pts;
@@ -40,4 +37,38 @@ private:
   CRhinoCacheHandle* m_device_cache_handle;
 
   ON_BoundingBox m_bounding_box;
+};
+
+class RhinoVrFrustumConduit : public CRhinoDisplayConduit
+{
+public:
+  RhinoVrFrustumConduit();
+
+  bool ExecConduit(CRhinoDisplayPipeline& dp, UINT nActiveChannel, bool& bTerminateChannel) override;
+  void Enable(unsigned int uiDocSerialNumber);
+
+  void SetFrustumLeft(
+    double frus_near, double frus_far,
+    double frus_left, double frus_right,
+    double frus_top, double frus_bottom);
+
+  void SetFrustumRight(
+    double frus_near, double frus_far,
+    double frus_left, double frus_right,
+    double frus_top, double frus_bottom);
+
+private:
+  double m_left_frus_near;
+  double m_left_frus_far;
+  double m_left_frus_left;
+  double m_left_frus_right;
+  double m_left_frus_top;
+  double m_left_frus_bottom;
+
+  double m_right_frus_near;
+  double m_right_frus_far;
+  double m_right_frus_left;
+  double m_right_frus_right;
+  double m_right_frus_top;
+  double m_right_frus_bottom;
 };

--- a/RhinoVR/RhinoVrDeviceDisplayConduit.h
+++ b/RhinoVR/RhinoVrDeviceDisplayConduit.h
@@ -14,9 +14,10 @@ public:
   void SetDeviceMeshCacheHandle(CRhinoCacheHandle* cache_handle);
 
   void SetFrustumNearFarSuggestion(double frus_near, double frus_far);
-  void AddPlane(const ON_Plane& plane, double extent_x, double extent_y, const CDisplayPipelineMaterial* material);
+  void AddWindowMesh(const ON_Mesh& mesh, const CDisplayPipelineMaterial* material);
   void AddLine(const ON_3dPoint& from, const ON_3dPoint& to, const ON_Color& color);
   void Empty();
+  void InvalidateWindowMeshCache();
 
 private:
   double m_frus_near_suggestion;
@@ -26,8 +27,8 @@ private:
   ON_SimpleArray<ON_3dPoint> m_end_pts;
   ON_SimpleArray<ON_Color> m_colors;
 
-  ON_SimpleArray<ON_Plane> m_planes;
-  ON_ClassArray<ON_Mesh> m_mesh_planes;
+  ON_ClassArray<ON_Mesh> m_plane_meshes;
+  ON_ClassArray<ON_Xform> m_plane_xforms;
   ON_SimpleArray<const CDisplayPipelineMaterial*> m_plane_materials;
   ON_SimpleArray<CRhinoCacheHandle*> m_mesh_plane_cache_handles;
 

--- a/RhinoVR/RhinoVrRenderer.cpp
+++ b/RhinoVR/RhinoVrRenderer.cpp
@@ -572,7 +572,7 @@ void RhinoVrRenderer::UpdateDeviceDisplayConduits(
 
             if (BitBlt(app.m_dib, 0, 0, width, height, app_hdc, 0, 0, SRCCOPY))
             {
-              ON_FileReference file_ref = app.m_dib.GetTextureFileReference(app.m_crc);
+              ON_FileReference file_ref = RhinoGetDibAsTextureFileReference(app.m_dib, app.m_crc);
 
               ON_Texture tex;
               tex.m_mode = ON_Texture::MODE::decal_texture;
@@ -1285,7 +1285,7 @@ bool RhinoVrRenderer::HandleInput()
     bool is_right_hand = (device_idx == m_device_index_right_hand);
 
     HWND window = nullptr;
-    POINT window_pt;
+    POINT window_pt = {};
 
     if(m_device_index_left_hand < vr::k_unMaxTrackedDeviceCount &&
       m_device_index_right_hand < vr::k_unMaxTrackedDeviceCount)

--- a/RhinoVR/RhinoVrRenderer.h
+++ b/RhinoVR/RhinoVrRenderer.h
@@ -61,9 +61,10 @@ struct RhinoVrAppWindow
   CRhinoDib  m_dib;
   LONG       m_width = 0;
   LONG       m_height = 0;
-  ON_Plane   m_plane;
-  double     m_plane_width = 0.0;
-  double     m_plane_height = 0.0;
+  ON_Mesh    m_mesh;
+  double     m_mesh_width = 0.0;
+  double     m_mesh_height = 0.0;
+  double     m_opacity = 1.0;
   CDisplayPipelineMaterial m_material;
 };
 
@@ -143,6 +144,8 @@ protected:
 
   // Simulate Rhino's OnMouseMove in VR.
   void RhinoVrOnMouseMove(const ON_Xform& picking_device_xform);
+
+  bool RhinoVrGetIntersectingAppWindow(const RhinoVrAppWindow& app_window, const ON_Xform& ray_xform, const ON_Xform& window_mesh_xform, ON_3dPoint& world_point, ON_2dPoint& screen_uvs);
 
   // Find object intersection with an eye-space ray transformed by 'picking_device_xform'.
   // The eye-space ray is (0.0, 0.0, -frustum_near) to (0.0, 0.0, -frustum_far).

--- a/RhinoVR/RhinoVrRenderer.h
+++ b/RhinoVR/RhinoVrRenderer.h
@@ -58,11 +58,12 @@ struct RhinoVrAppWindow
   ON_wString m_title;
   ON__UINT32 m_crc = 0;
   HWND       m_hwnd = nullptr;
-  HBITMAP    m_bitmap = nullptr;
-  HDC        m_bitmap_hdc = nullptr;
+  CRhinoDib  m_dib;
   LONG       m_width = 0;
   LONG       m_height = 0;
   ON_Plane   m_plane;
+  double     m_plane_width = 0.0;
+  double     m_plane_height = 0.0;
   CDisplayPipelineMaterial m_material;
 };
 
@@ -273,6 +274,8 @@ protected:
 
   RhinoVrAppWindow m_gh_window;
   RhinoVrAppWindow m_rh_window;
+
+  RhTimestamp m_last_window_update;
 
   ON_Mesh m_hidden_mesh_left;  // The hidden area mesh for the left eye.
   ON_Mesh m_hidden_mesh_right; // The hidden area mesh for the right eye.

--- a/RhinoVR/RhinoVrRenderer.h
+++ b/RhinoVR/RhinoVrRenderer.h
@@ -275,8 +275,14 @@ protected:
   // The render models of all tracked devices.
   ON_ClassArray<std::unique_ptr<RhinoVrDeviceModel>> m_device_render_models;
 
+  RhinoVrFrustumConduit m_frustum_conduit;
+
   RhinoVrAppWindow m_gh_window;
   RhinoVrAppWindow m_rh_window;
+
+  bool m_gh_window_left_btn_down;
+  bool m_gh_window_zoomed_this_frame;
+  bool m_gh_window_panned_this_frame;
 
   RhTimestamp m_last_window_update;
 

--- a/RhinoVR/RhinoVrRenderer.h
+++ b/RhinoVR/RhinoVrRenderer.h
@@ -52,6 +52,20 @@ struct RhinoVrDeviceController
   ON_2dPoint m_touchpad_touch_point = ON_2dPoint::Origin;
 };
 
+struct RhinoVrAppWindow
+{
+  bool       m_enabled = false;
+  ON_wString m_title;
+  ON__UINT32 m_crc = 0;
+  HWND       m_hwnd = nullptr;
+  HBITMAP    m_bitmap = nullptr;
+  HDC        m_bitmap_hdc = nullptr;
+  LONG       m_width = 0;
+  LONG       m_height = 0;
+  ON_Plane   m_plane;
+  CDisplayPipelineMaterial m_material;
+};
+
 // This struct contains up-to-date information of a tracked
 // VR device, such as location/orientation, geometry, and
 // the state of any buttons/triggers/touchpads.
@@ -256,6 +270,9 @@ protected:
 
   // The render models of all tracked devices.
   ON_ClassArray<std::unique_ptr<RhinoVrDeviceModel>> m_device_render_models;
+
+  RhinoVrAppWindow m_gh_window;
+  RhinoVrAppWindow m_rh_window;
 
   ON_Mesh m_hidden_mesh_left;  // The hidden area mesh for the left eye.
   ON_Mesh m_hidden_mesh_right; // The hidden area mesh for the right eye.

--- a/RhinoVR/RhinoVrRenderer.h
+++ b/RhinoVR/RhinoVrRenderer.h
@@ -281,10 +281,14 @@ protected:
   RhinoVrAppWindow m_rh_window;
 
   bool m_gh_window_left_btn_down;
-  bool m_gh_window_zoomed_this_frame;
-  bool m_gh_window_panned_this_frame;
+  bool m_window_intersected_this_frame;
 
   RhTimestamp m_last_window_update;
+
+  double m_move_speed; // Movement speed in meters per second
+  double m_turn_speed; // Turning speed in degrees per second
+  double m_last_frame_time;
+  RhTimestamp m_frame_timestamp;
 
   ON_Mesh m_hidden_mesh_left;  // The hidden area mesh for the left eye.
   ON_Mesh m_hidden_mesh_right; // The hidden area mesh for the right eye.


### PR DESCRIPTION
- Now possible to open an application window (e.g. Grasshopper window) by clicking and holding the left trigger button.
- The following actions are simulated on the application window: MouseLeftDown, MouseLeftUp, MouseRightDown, MouseRightUp, MouseScroll, MouseMove.
- Clicking, zooming and panning and dragging is supported on the Grasshopper window.
- Movement speed is now based on time elapsed, not speed of rendering.